### PR TITLE
feature: add env guard to api route and to project card.

### DIFF
--- a/env.ts
+++ b/env.ts
@@ -1,0 +1,16 @@
+export interface EnvData {
+  NEXT_PUBLIC_GITHUB_FETCH_ENABLED: string;
+  NEXT_PUBLIC_GH_OWNER: string;
+  GITHUB_TOKEN?: string;
+}
+
+// this is to avoid calling process.env multiple times
+// calling process.env is expensive, so i added a small performance optimization
+export const getEnvData = (): EnvData => {
+  return {
+    NEXT_PUBLIC_GITHUB_FETCH_ENABLED:
+      process.env.NEXT_PUBLIC_ENABLE_GITHUB_FETCH || "false",
+    NEXT_PUBLIC_GH_OWNER: process.env.NEXT_PUBLIC_GH_OWNER || "",
+    GITHUB_TOKEN: process.env.GITHUB_TOKEN,
+  };
+};

--- a/src/app/api/github/[repo]/route.ts
+++ b/src/app/api/github/[repo]/route.ts
@@ -1,24 +1,41 @@
 import { NextResponse } from "next/server";
+import { EnvData, getEnvData } from "../../../../../env";
 
+const envData: EnvData = getEnvData();
 export async function GET(
   request: Request,
   { params }: { params: { repo: string } }
 ) {
   const repo = params.repo;
+  const enableGithubFetch = envData.NEXT_PUBLIC_GITHUB_FETCH_ENABLED === "true";
+  const githubOwner = envData.NEXT_PUBLIC_GH_OWNER;
+
+  if (!enableGithubFetch || !githubOwner) {
+    return NextResponse.json(
+      { error: "GitHub fetching disabled. See README to configure env." },
+      { status: 400 }
+    );
+  }
 
   try {
+    const headers: HeadersInit = {
+      Accept: "application/vnd.github.v3+json",
+    };
+
+    if (envData.GITHUB_TOKEN) {
+      headers["Authorization"] = `token ${envData.GITHUB_TOKEN}`;
+    }
+
     const response = await fetch(
-      `https://api.github.com/repos/akadeepesh/${repo}`,
-      {
-        headers: {
-          Authorization: `token ${process.env.GITHUB_TOKEN}`,
-          Accept: "application/vnd.github.v3+json",
-        },
-      }
+      `https://api.github.com/repos/${githubOwner}/${repo}`,
+      { headers }
     );
 
     if (!response.ok) {
-      throw new Error("GitHub API request failed");
+      return NextResponse.json(
+        { error: "Failed to fetch repository data from GitHub API" },
+        { status: response.status }
+      );
     }
 
     const data = await response.json();
@@ -37,7 +54,7 @@ export async function GET(
   } catch (error) {
     console.error("Error fetching repo data:", error);
     return NextResponse.json(
-      { error: "Failed to fetch repository data" },
+      { error: "An unexpected error occurred" },
       { status: 500 }
     );
   }

--- a/src/app/api/github/[repo]/route.ts
+++ b/src/app/api/github/[repo]/route.ts
@@ -32,6 +32,13 @@ export async function GET(
     );
 
     if (!response.ok) {
+      if (response.status === 404) {
+        return NextResponse.json(
+          { error: "Repository not found. Please make sure the repository name is valid." },
+          { status: 404 }
+        );
+      }
+
       return NextResponse.json(
         { error: "Failed to fetch repository data from GitHub API" },
         { status: response.status }

--- a/src/components/SkillsAndProjects.tsx
+++ b/src/components/SkillsAndProjects.tsx
@@ -137,7 +137,7 @@ const ProjectCard: React.FC<ProjectInfo> = ({ name }) => {
   const [repoData, setRepoData] = useState<RepoData | null>(null);
   const [isHovered, setIsHovered] = useState(false);
   const [loading, setLoading] = useState(true);
-  const [error, setError] = useState(false);
+  const [error, setError] = useState<string | null>(null);
   const [githubFetchEnabled, setGithubFetchEnabled] = useState(true);
 
   useEffect(() => {
@@ -157,14 +157,16 @@ const ProjectCard: React.FC<ProjectInfo> = ({ name }) => {
         if (response.ok) {
           const data = await response.json();
           setRepoData(data);
+          setError(null);
           
         } else{
-          setError(true);
+          const errorData = await response.json();
+          setError(errorData.error || "Failed to load repository data.");
         }
         
       } catch (error) {
         console.error("Error fetching repo data:", error);
-        setError(true);
+        setError("Failed to load repository data.");
         
       } finally {
         setLoading(false);
@@ -317,7 +319,7 @@ const ProjectCard: React.FC<ProjectInfo> = ({ name }) => {
 
         {error && (
           <p className="mt-3 text-sm text-red-500 dark:text-red-400">
-            Failed to load repository data.
+            {error}
           </p>
         )}
 


### PR DESCRIPTION
This PR adds the following features:

#### frontend guard
- added a **guard** that checks if the `NEXT_PUBLIC_GH_OWNER` and `NEXT_PUBLIC_ENABLE_GITHUB_FETCH` are configured.
- added display of `custom error message` if github api fetch fails (404, or any other network/api issues).
- added a new state called `githubFetchEnabled` that is used to display the guidance message within the card.

#### api guard
- added a **guard** that checks if the `NEXT_PUBLIC_GH_OWNER` and `NEXT_PUBLIC_ENABLE_GITHUB_FETCH` are configured. 
- If not configured, the api returns a `400` error message with a JSON message:
```
{ error: "GitHub fetching disabled. See README to configure env." }
```
- added condition to use `GITHUB_TOKEN` only if its available, else, the request will be sent without a token

Additionally, added a new file called `env.ts` that reads the environment variable values and puts it into an **object**.
This is a small performance optimization since `process.env` calls are expensive.