### PR TITLE
 Feature Added: GitHub Integration Helper Message

### DIFF
--- a/src/components/SkillsAndProjects.tsx
+++ b/src/components/SkillsAndProjects.tsx
@@ -25,6 +25,7 @@ import {
   ArrowUpRight,
   Activity,
   AlertCircle,
+  Info,
 } from "lucide-react";
 import WordPressSkills from "./WordPressSkills";
 import { EnvData, getEnvData } from "../../env";
@@ -235,9 +236,9 @@ const ProjectCard: React.FC<ProjectInfo> = ({ name }) => {
                 />
               )}
             </div>
-            <h3 className="text-lg font-semibold text-gray-900 dark:text-gray-100 truncate">
+            <h4 className="text-lg font-semibold text-gray-900 dark:text-gray-100 truncate">
               {name}
-            </h3>
+            </h4>
           </div>
 
           {loading && (
@@ -363,6 +364,20 @@ const SkillDialog: React.FC<SkillDialogProps> = ({ skill }) => (
             {skill} Projects
           </DialogTitle>
         </DialogHeader>
+        
+        {/* Helper Message Banner */}
+        <div className="mb-4 p-3 rounded-lg bg-blue-50 dark:bg-blue-900/20 border border-blue-200 dark:border-blue-800/50">
+          <div className="flex items-start gap-2">
+            <Info className="w-4 h-4 text-blue-600 dark:text-blue-400 mt-0.5 flex-shrink-0" />
+            <div className="text-sm text-blue-700 dark:text-blue-300">
+              <p className="font-medium">Tip: These cards can show live GitHub stats.</p>
+              <p className="mt-1 text-blue-600 dark:text-blue-400">
+                Set <code className="px-1 py-0.5 bg-blue-100 dark:bg-blue-800/50 rounded text-xs font-mono">NEXT_PUBLIC_GH_OWNER</code> to your GitHub username to fetch stars, forks, and topics for each project.
+              </p>
+            </div>
+          </div>
+        </div>
+
         <ScrollArea className="h-[60vh] pr-4">
           <AnimatePresence>
             <div className="grid grid-cols-1 gap-4">


### PR DESCRIPTION

<img width="1914" height="895" alt="Screenshot 2025-10-05 104352" src="https://github.com/user-attachments/assets/bebb80d2-48ea-4315-b3c2-2953f5573d83" />
Location: SkillsAndProjects.tsx - Inside the SkillDialog component

Trigger: Appears when users click any skill badge (Python, TypeScript, Next.js, etc.)

Message Content:

Line 1: "Tip: These cards can show live GitHub stats." Line 2: "Set NEXT_PUBLIC_GH_OWNER to your GitHub username to fetch stars, forks, and topics for each project." Visual Design:

🔵 Blue info icon on the left
Light blue background with border
Code snippet highlighting for the environment variable Responsive layout that works on all screen sizes
✅ Acceptance Criteria Met:
Requirement	Status	Implementation
Helper message visible on dialog open	✅ Complete	Banner appears at top of every skill dialog Clear explanation of GitHub feature	✅ Complete	Explains live stats fetching and configuration Mobile responsive	✅ Complete	Flexible layout, no overflow issues Dark mode support	✅ Complete	Blue theme with proper contrast ratios 🛠️ Technical Details:
Code Changes:

Added Info icon import from Lucide React
Inserted banner between DialogHeader and ScrollArea Fixed HTML heading hierarchy (h3 → h4) to resolve hydration error Styling:

Light mode: bg-blue-50, border-blue-200, text-blue-700 Dark mode: dark:bg-blue-900/20, dark:border-blue-800/50, dark:text-blue-300 Responsive: Flexbox layout with proper text wrapping 🎨 User Experience:
Before: Template users had no indication that project cards could show live GitHub data

After: Clear, educational banner that:

Explains the GitHub integration feature
Shows exactly which environment variable to configure Provides context about what data gets fetched (stars, forks, topics) Maintains professional, non-intrusive design
The implementation successfully bridges the knowledge gap for template users while maintaining excellent UX and technical standards.